### PR TITLE
Allow event name overrides

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -55,6 +55,14 @@ ___TEMPLATE_PARAMETERS___
     "alwaysInSummary": true
   },
   {
+    "type": "TEXT",
+    "name": "eventNameOverride",
+    "displayName": "Event Name Override",
+    "simpleValueType": true,
+    "alwaysInSummary": true,
+    "help": "Leave blank to inherit from common event properties"
+  },
+  {
     "type": "GROUP",
     "name": "brazeIdentifierGroup",
     "displayName": "Identity settings",
@@ -1179,7 +1187,7 @@ const mkEventObject = (evData, tagConfig) => {
   const properties = mkEventProperties(evData, tagConfig);
 
   return {
-    name: evData.event_name,
+    name: tagConfig.eventNameOverride || evData.event_name,
     time: getEventTime(tagConfig),
     properties: properties,
   };


### PR DESCRIPTION
As far as I can see, there is no easy way to override the event name in the payload which is sent to Braze (i.e. it's always taken from the [common event data](https://developers.google.com/tag-platform/tag-manager/server-side/common-event-data)). Attempting to override it using the Additional Event Mapping Options just creates an `event_name` key in the `properties` object. 

Would it be possible to add an override option? See my attached example.

Thanks! 